### PR TITLE
refactor: [박지영] 백엔드에서 기존의 @CrossOrigin 어노테이션 삭제하고 CorsConfig 구성하기 [BY…

### DIFF
--- a/byl_process/src/main/java/com/jgj/byl_process/domain/board/controller/BoardController.java
+++ b/byl_process/src/main/java/com/jgj/byl_process/domain/board/controller/BoardController.java
@@ -13,7 +13,6 @@ import java.util.List;
 @RestController
 @RequestMapping("/board")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "http://localhost:8080", allowedHeaders = "*")
 public class BoardController {
 
     final private BoardService boardService;

--- a/byl_process/src/main/java/com/jgj/byl_process/domain/boards/product/controller/ProductController.java
+++ b/byl_process/src/main/java/com/jgj/byl_process/domain/boards/product/controller/ProductController.java
@@ -15,7 +15,6 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/product")
-@CrossOrigin(origins = "http://localhost:8080", allowedHeaders = "*")
 public class ProductController {
 
     final private ProductService productService;

--- a/byl_process/src/main/java/com/jgj/byl_process/domain/config/WebConfig.java
+++ b/byl_process/src/main/java/com/jgj/byl_process/domain/config/WebConfig.java
@@ -9,7 +9,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/*")
+        registry.addMapping("/**")
                 .allowedOrigins("http://127.0.0.1:8080")
                 .allowedOrigins("http://localhost:8080")
                 .allowedMethods("GET", "POST", "PUT", "DELETE");

--- a/byl_process/src/main/java/com/jgj/byl_process/domain/member/controller/MemberController.java
+++ b/byl_process/src/main/java/com/jgj/byl_process/domain/member/controller/MemberController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/member")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "http://localhost:8080", allowedHeaders = "*")
 public class MemberController {
 
     final private MemberService memberService;

--- a/byl_process/src/main/resources/application.yaml
+++ b/byl_process/src/main/resources/application.yaml
@@ -24,6 +24,8 @@ spring:
   redis:
     host: 127.0.0.1
     port: 6379
+    username: default
+    password: wldud@123
 
   servlet:
     multipart:


### PR DESCRIPTION
…L-BACK-PROCESS-20]

- 모든 컨트롤러에 @CrossOrigin 어노테이션 삭제함
- WebConfig 에 registry.addMapping("/**") 오타수정